### PR TITLE
Fix misaligned top border on ListItem after element

### DIFF
--- a/themes/ios/styles/ListItem.js
+++ b/themes/ios/styles/ListItem.js
@@ -115,7 +115,8 @@ module.exports = (c) => ({
     color: c.listItemAfterColor,
     flexShrink: 0,
     WebkitFlexShrink: 0,
-    margin: 'auto 12px',
+    padding: '0 12px',
+    justifyContent: 'center',
     whiteSpace: 'nowrap',
     alignSelf: 'stretch',
     WebkitAlignSelf: 'stretch'


### PR DESCRIPTION
Due to the nature of the box model, the specified border on the `after` element
does not line up with the rest of the ListItem's top border. I used the flex
model's `justifyContent` property to center the `after` content vertically and
turned the remaining `margin` into a `padding` property.
