### PR TITLE
make Icon svg vertical center

### DIFF
--- a/components/Icon.jsx
+++ b/components/Icon.jsx
@@ -79,6 +79,10 @@ module.exports = Component({
       fill: color
     });
 
+    this.addStyles('svg', {
+      margin: 'auto',
+    });
+
     if (stroke)
       Object.assign(props, {
         stroke: color,
@@ -88,7 +92,7 @@ module.exports = Component({
 
     return (
       <div {...this.componentProps()}>
-        <svg viewBox="0 0 64 64" {...props}>
+        <svg viewBox="0 0 64 64" {...props} {...this.componentProps('svg')}>
           <g dangerouslySetInnerHTML={{__html: file }} />
         </svg>
       </div>


### PR DESCRIPTION
on kitchen sink, this page is buggy: http://kitchen.reapp.io/bars

I found the problem is the svg is not vertical centered, so made this change.
