### PR TITLE
solve buggy bar item rendering

### DIFF
--- a/components/BarItem.jsx
+++ b/components/BarItem.jsx
@@ -64,8 +64,8 @@ module.exports = Component({
 
     return (
       <li {...this.componentProps()} {...this.tappableProps()} {...props}>
-        {this.makeSection('icon', icon)}
-        {this.makeSection('text', children)}
+        {display != 'text' ? this.makeSection('icon', icon) : ''}
+        {display != 'icon' ? this.makeSection('text', children) : ''}
       </li>
     );
   }


### PR DESCRIPTION
I try to solve the bug of kitchen sink's bar page, but not able to find it. I doubt it maybe a bug in React diff  engine or something. so I did a simple change to avoid it for now. please consider merge it.
