### PR TITLE
Change brandColorInactive .

### DIFF
--- a/src/themes/ios/constants/base.js
+++ b/src/themes/ios/constants/base.js
@@ -33,7 +33,7 @@ export default {
   dark: '#8e8e93',
 
   brandColor: brandColor,
-  brandColorInactive: '#dcdbe2',
+  brandColorInactive: '#a3a3a3',
 
   active: brandColor,
   inactive: mid,


### PR DESCRIPTION
The current color is too light and makes tab icons look disabled rather than unselected. There is no 'correct' color, as the iOS tab bar is translucent, and so affected by the underlying color. I lifted this color from the iOS8 clock app which has a neutral background.
