### PR TITLE
Added "custom" modal type which shows no alert or confirm buttons

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -16,13 +16,15 @@ var Modal = Component({
     open: React.PropTypes.bool,
     type: React.PropTypes.oneOf([
       'alert', // OK
-      'confirm' // Cancel | OK
+      'confirm', // Cancel | OK
+      'custom'
     ]),
     animationDuration: React.PropTypes.number,
     animations: React.PropTypes.object,
     onConfirm: React.PropTypes.func,
     onCancel: React.PropTypes.func,
-    onClose: React.PropTypes.func
+    onClose: React.PropTypes.func,
+    bgTapClose: React.PropTypes.bool
   },
 
   getDefaultProps() {
@@ -30,6 +32,7 @@ var Modal = Component({
       open: true,
       type: 'alert',
       onClose: this.handleClose,
+      bgTapClose: true,
       animationDuration: 200,
       animations: {
         modal: ['fade', 'scaleDown'],

--- a/src/components/ModalPortal.jsx
+++ b/src/components/ModalPortal.jsx
@@ -39,6 +39,11 @@ module.exports = Component({
     this.handleClose(e);
   },
 
+  handleBgClose() {
+    if (this.props.bgTapClose)
+      this.handleClose()
+  },
+
   handleClose(e) {
     this.afterClose(e);
     // todo: this broke with portals
@@ -89,6 +94,9 @@ module.exports = Component({
           <ModalButton confirm onTap={this.handleConfirm} stopPropagation>OK</ModalButton>
         ];
         break;
+      case 'custom':
+        buttons = [];
+        break;
     }
 
     var buttonWidth = (100 / buttons.length) + '%';
@@ -102,7 +110,7 @@ module.exports = Component({
       <div {...this.componentProps()} {...props}>
         <Tappable
           {...this.componentProps('bg')}
-          onTap={this.handleClose}
+          onTap={this.handleBgClose}
           stopPropagation
         />
         <div {...this.componentProps('modal')}>


### PR DESCRIPTION
@natew We have added a new "custom" type to the Modal component that displays no alert/confirm buttons to allow for a completely custom Modal. We also added a new boolean prop, bgTapClose, to indicate whether to close the modal when the user taps the background, defaulting to true, so it shouldn't break any existing usage.
