### PR TITLE
Workaround for Safari bug with deeply nested flexboxes

### DIFF
--- a/assets/styles/ios/base.css
+++ b/assets/styles/ios/base.css
@@ -3,14 +3,6 @@
 }
 
 div, a, button, input, form {
-  display: flex;
-  display: -webkit-flex;
-  flex-flow: column;
-  -webkit-flex-flow: column;
-  flex-shrink: 0;
-  -webkit-flex-shrink: 0;
-  align-items: stretch;
-  -webkit-align-items: stretch;
   box-sizing: border-box;
   -webkit-tap-highlight-color: transparent;
   -webkit-touch-callout: none;
@@ -85,6 +77,17 @@ p {
 p a {
   display: inline-block;
   text-decoration: underline;
+}
+
+.flex {
+  display: flex;
+  display: -webkit-flex;
+  flex-flow: column;
+  -webkit-flex-flow: column;
+  flex-shrink: 0;
+  -webkit-flex-shrink: 0;
+  align-items: stretch;
+  -webkit-align-items: stretch;
 }
 
 .ListItem {


### PR DESCRIPTION
@natew Feel free to reject this pull request if you feel it's too invasive and have other suggestions on how to deal with the issue, but I wanted you to at least see our workaround. You can see that it just moves the flexbox stuff to its own class and removes it from the global div/a/button/input/form styles. That will obviously greatly affect layout using the iOS theme, and the Safari bug may not be observed on iPhone as opposed to iPad, due to limited screen real estate. Let us know if we can provide any information to the Safari guys in order to reproduce. 
