### PR TITLE
fix scrolling issues on chrome (android & desktop)

### DIFF
--- a/src/themes/ios/styles/View.js
+++ b/src/themes/ios/styles/View.js
@@ -16,6 +16,7 @@ export default c => ({
     background: c.viewBG,
     zIndex: 1,
     flex: 1,
+    height: '100%',
     position: 'relative'
   },
 


### PR DESCRIPTION
On Chrome, when only specifying `flex: 1` for the inner view, the height of the inner view is the height of the content and not the height of its parent - therefore, scrolling doesn't work. As far as I know it is only true for Chrome (tested on safari for iOS/OSX). The solution is the add `height: 100%`.

In any way, specifying the height is 100% is a good practice because this is the truth in this case.
